### PR TITLE
[#9] [enhancement] use scoreboards to track waypoints, allowing for a more performant and more multiplayer-friendly implementation

### DIFF
--- a/data/assassin/functions/tp_to_waypoint.mcfunction
+++ b/data/assassin/functions/tp_to_waypoint.mcfunction
@@ -1,0 +1,7 @@
+execute store result entity @s Pos[0] double 1 run scoreboard players get @p xpos
+execute store result entity @s Pos[1] double 1 run scoreboard players get @p ypos
+execute store result entity @s Pos[2] double 1 run scoreboard players get @p zpos
+execute store result entity @s Rotation[0] float 1 run scoreboard players get @p yaw
+execute store result entity @s Rotation[1] float 1 run scoreboard players get @p pitch
+tp @e[distance=0..5,type=!minecraft:item_frame,type=!minecraft:glow_item_frame] @s
+kill @s

--- a/data/assassin/powers/smokes/waypoint.json
+++ b/data/assassin/powers/smokes/waypoint.json
@@ -1,6 +1,5 @@
 {
 	"type": "origins:multiple",
-	
 	"name": "Ender Smoke",
 	"description": "You recently discovered that some strange things happen when adding an ender pearl to your smoke, with the effects changing depending on what hand you hold the item in.",
 	"badges": [
@@ -35,6 +34,35 @@
 			}
 		}
 	],
+
+	"create_scoreboards": {
+		"type": "origins:action_on_callback",
+		"entity_action_chosen": {
+			"type": "origins:and",
+			"actions": [
+				{
+					"type": "origins:execute_command",
+					"command": "scoreboard objectives add xpos dummy"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "scoreboard objectives add ypos dummy"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "scoreboard objectives add zpos dummy"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "scoreboard objectives add yaw dummy"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "scoreboard objectives add pitch dummy"
+				}
+			]
+		}
+	},
 	
 	"discard_waypoint": {
 		"type": "origins:active_self",
@@ -46,18 +74,10 @@
 					"command": "title @s actionbar {\"text\": \"Your waypoint has been discarded.\", \"color\": \"red\", \"bold\": true"
 				},
 				{
-					"type": "origins:execute_command",
-					"command": "kill @e[tag=AssassinWaypoint]"
-				},
-				{
 					"type": "origins:change_resource",
 					"resource": "*:*_resource",
 					"change": 0,
 					"operation": "set"
-				},
-				{
-					"type": "origins:execute_command",
-					"command": "forceload remove all"
 				}
 			]
 		},
@@ -115,7 +135,11 @@
 				},
 				{
 					"type": "origins:execute_command",
-					"command": "execute as @e[distance=0..5,type=!minecraft:item_frame,type=!minecraft:glow_item_frame] at @e[tag=AssassinWaypoint] run tp ~ ~ ~"
+					"command": "summon minecraft:marker ~ ~ ~ {Tags:[\"AssassinWaypoint\"]}"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "execute as @e[type=minecraft:marker,tag=AssassinWaypoint] run function assassin:tp_to_waypoint"
 				},
 				{
 					"type": "origins:spawn_particles",
@@ -144,20 +168,12 @@
 					"operation": "set"
 				},
 				{
-					"type": "origins:execute_command",
-					"command": "kill @e[tag=AssassinWaypoint]"
-				},
-				{
 					"type": "origins:equipped_item_action",
 					"equipment_slot": "offhand",
 					"action": {
 						"type": "origins:consume",
 						"amount": 1
 					}
-				},
-				{
-					"type": "origins:execute_command",
-					"command": "forceload remove all"
 				}
 			]
 		},
@@ -215,11 +231,23 @@
 			"actions": [
 				{
 					"type": "origins:execute_command",
-					"command": "kill @e[tag=AssassinWaypoint]"
+					"command": "execute as @s store result score @s xpos run data get entity @s Pos[0]"
 				},
 				{
 					"type": "origins:execute_command",
-					"command": "summon minecraft:armor_stand ~ ~ ~ {NoGravity:1, Invulnerable:1, Invisible:1, Tags:[\"AssassinWaypoint\"]}"
+					"command": "execute as @s store result score @s ypos run data get entity @s Pos[1]"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "execute as @s store result score @s zpos run data get entity @s Pos[2]"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "execute as @s store result score @s yaw run data get entity @s Rotation[0]"
+				},
+				{
+					"type": "origins:execute_command",
+					"command": "execute as @s store result score @s pitch run data get entity @s Rotation[1]"
 				},
 				{
 					"type": "origins:execute_command",
@@ -254,10 +282,6 @@
 						"type": "origins:consume",
 						"amount": 1
 					}
-				},
-				{
-					"type": "origins:execute_command",
-					"command": "forceload add ~ ~"
 				}
 			]
 		},


### PR DESCRIPTION
title, also now tracks yaw and pitch meaning player will be given the rotation when going to waypoint

massive thanks to `@cestmoi_` in the origins discord, gave tonnes of useful info, wouldve taken so much longer without him